### PR TITLE
Fix username in k8s auth token

### DIFF
--- a/internal/gateway/usecases/get_auth_token.go
+++ b/internal/gateway/usecases/get_auth_token.go
@@ -90,7 +90,7 @@ func (s *getAuthTokenUsecase) Run(ctx context.Context) error {
 		return err
 	}
 
-	username := strings.ToLower(user.Name)
+	username := strings.ToLower(strings.Split(user.GetEmail(), "@")[0])
 	if s.request.GetRole() != string(k8s.DefaultRole) {
 		username = fmt.Sprintf("%s-%s", username, s.request.GetRole())
 	}


### PR DESCRIPTION
The k8s auth token was using the username which is able to change and then does not match clusterrolebindings and rolebindings in target clusters anymore.