### PR TITLE
Make RabbitEventBusConfig fields accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Make fields of the `RabbitEventBusConfig` public so that the exchange name can be overwritten.


### PR DESCRIPTION
Currently it is not possible to change the exchange name that is used
for publishing messages. It is always set to the value `m8_events`. This
is inconvenient for other projects that want to take advantage of the
message bus implementation.

I considered adding a new parameter to the `NewRabbitEventBusConfig` function
but that would potentially break other implementations. On the other hand I
couldn't think of a good reason why the fields of the config struct should actually
be private. Only the `url` has some logic bound to it, because the TLS settings
have conditionally to be reconfigured. For that reason I added a setter `SetURL`.