### PR TITLE
store_refresh_middleware seems to be buggy

### DIFF
--- a/pkg/eventsourcing/eventhandler/store_refresh_middleware.go
+++ b/pkg/eventsourcing/eventhandler/store_refresh_middleware.go
@@ -89,7 +89,7 @@ func (m *eventStoreRefreshEventHandler) applyEventsFromStore(ctx context.Context
 
 	// Retrieve events from store
 	eventStream, err := m.esClient.Retrieve(ctx, &apiEs.EventFilter{
-		MinTimestamp:  timestamppb.New(m.lastTimestamp.Add(1)),
+		MinTimestamp:  timestamppb.New(m.lastTimestamp),
 		AggregateType: wrapperspb.String(m.aggregateType.String()),
 	})
 	if err != nil {
@@ -115,7 +115,7 @@ func (m *eventStoreRefreshEventHandler) applyEventsFromStore(ctx context.Context
 			return err
 		}
 
-		m.log.Info("Applying event which wasn't received via bus from store.", "event", event.String())
+		m.log.V(logger.DebugLevel).Info("Applying event which wasn't received via bus from store.", "event", event.String())
 
 		// Let the next handler in the chain handle the event
 		err = m.handler.HandleEvent(ctx, event)


### PR DESCRIPTION
It has been observed that events are replayed even though they have been observed already.

So here’s the problem: The refresh middleware uses the timestamp of the last received event to query all events later than that. This is kind of bullshit and I will explain why:

* Even though an Event with a certain timestamp has been received, there could be a second event with the exact same timestamp that has been gone missing. So querying all events later than that won’t rescue you.
* Timestamps are in general something that are error prone because we all know time is something funny which can hit you pretty hard in the face.

It would be better to have a global event counter. Due to the nature of distributed systems we do not have something like that because this would need some kind of distributed transaction to make sure the exact count. And Greg Young says “Trying to provide those things leads to the dark side”, so we don’t go down that road.

So what do we do? There are several ways to mitigate this:

* Don’t have refresh middleware on aggregate type level but per single aggregate encountered in the QueryHandler. This only works for observed aggregates. Say we miss the initial event of a new aggregate, we won’t notice still. That’s bad.
* Just ignore it and let it replay some events periodically even though they’ve been observed already. That doesn’t do any harm beside some lost CPU cycles.

For now we will go with the latter approach.