### PR TITLE
Resolve message type when unmarshaling EventData

### DIFF
--- a/pkg/eventsourcing/event_data.go
+++ b/pkg/eventsourcing/event_data.go
@@ -16,7 +16,7 @@ package eventsourcing
 
 import (
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -33,7 +33,7 @@ func toEventDataFromAny(a *anypb.Any) EventData {
 }
 
 // ToEventDataFromProto marshalls m into EventData.
-func ToEventDataFromProto(m protoreflect.ProtoMessage) EventData {
+func ToEventDataFromProto(m proto.Message) EventData {
 	a := &anypb.Any{}
 	if err := a.MarshalFrom(m); err != nil {
 		panic(err)
@@ -52,10 +52,20 @@ func (d EventData) toAny() (*anypb.Any, error) {
 }
 
 // ToProto unmarshals the contents the EventData into m.
-func (d EventData) ToProto(m protoreflect.ProtoMessage) error {
+func (d EventData) ToProto(m proto.Message) error {
 	a, err := d.toAny()
 	if err != nil {
 		return err
 	}
 	return a.UnmarshalTo(m)
+}
+
+// Unmarshal deserializes the EventData into a proto message using a type resolved from
+// the type URL.
+func (d EventData) Unmarshal() (proto.Message, error) {
+	a, err := d.toAny()
+	if err != nil {
+		return nil, err
+	}
+	return a.UnmarshalNew()
 }

--- a/pkg/eventsourcing/event_data_test.go
+++ b/pkg/eventsourcing/event_data_test.go
@@ -27,7 +27,7 @@ var _ = Describe("EventData", func() {
 	}
 	eventDataFromProto := func() EventData {
 		eventData := ToEventDataFromProto(getProto())
-		Expect(eventData).To(Not(BeNil()))
+		Expect(eventData).ToNot(BeNil())
 		return eventData
 	}
 
@@ -38,22 +38,30 @@ var _ = Describe("EventData", func() {
 		proto := getProto()
 		any := anypb.Any{}
 		err := any.MarshalFrom(proto)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).ToNot(HaveOccurred())
 
 		eventData := toEventDataFromAny(&any)
-		Expect(eventData).To(Not(BeNil()))
+		Expect(eventData).ToNot(BeNil())
 	})
-	It("can unmarshall to any", func() {
+	It("can unmarshal to any", func() {
 		eventData := eventDataFromProto()
 		any, err := eventData.toAny()
-		Expect(err).To(Not(HaveOccurred()))
-		Expect(any).To(Not(BeNil()))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(any).ToNot(BeNil())
 	})
-	It("can unmarshall to proto", func() {
+	It("can unmarshal to proto", func() {
 		eventData := eventDataFromProto()
 		proto := &cmdApi.TestCommandData{}
 		err := eventData.ToProto(proto)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).ToNot(HaveOccurred())
 		Expect(proto.GetTest()).To(Equal(getProto().GetTest()))
+	})
+	It("can resolve message type on unmarshal", func() {
+		eventData := eventDataFromProto()
+		proto, err := eventData.Unmarshal()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(proto).ToNot(BeNil())
+		_, ok := proto.(*cmdApi.TestCommandData)
+		Expect(ok).To(BeTrue())
 	})
 })


### PR DESCRIPTION
When an event, despite having the same type, can have different payloads, it would helpful to wrap the [anypb.UnmarshalNew](https://pkg.go.dev/google.golang.org/protobuf/types/known/anypb#UnmarshalNew) function in order to offload the message resolution to `anypb`