### PR TITLE
Remove changelog in favor of releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-- Make fields of the `RabbitEventBusConfig` public so that the exchange name can be overwritten.


### PR DESCRIPTION
This has slipped through somewhere. Actually we do not need that since we already have detailed release information on the release page of the project.