### PR TITLE
Adjust allowed paths to all users for cluster login

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -3,13 +3,16 @@ name: Draft Release
 on:
   push:
     branches: [ main ]
+  # pull_request event is required only for autolabeler
   pull_request:
-    branches: [ main ]
-      
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
 jobs:
   draft-release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Update draft
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -23,7 +23,8 @@ on:
 env:
   GO_MODULE: github.com/finleap-connect/monoskope
   GO_VERSION: 1.18.x
-  GINKGO_VERSION: v1.16.4
+  GINKGO_VERSION: v1.16.5
+  GO_CI_LINT_VERSION: v1.46.1
 
 jobs:
   lint:
@@ -38,7 +39,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: ${{ env.GO_CI_LINT_VERSION }}
           args: --timeout=5m
 
   test:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -59,7 +59,7 @@ jobs:
           GINKGO=ginkgo make go-test-ci
           make go-coverage
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.8
+        uses: jandelgado/gcov2lcov-action@v1.2.0
         with:
           infile: monoskope.coverprofile
       - name: Coveralls GitHub Action

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -59,7 +59,7 @@ jobs:
           GINKGO=ginkgo make go-test-ci
           make go-coverage
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.2.0
+        uses: jandelgado/gcov2lcov-action@v1.0.8
         with:
           infile: monoskope.coverprofile
       - name: Coveralls GitHub Action

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -57,12 +57,12 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
           GINKGO=ginkgo make go-test-ci
-      - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.8
-        with:
-          infile: monoskope.coverprofile
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.github_token }}
-          path-to-lcov: coverage.lcov
+      # - name: Convert coverage to lcov
+      #   uses: jandelgado/gcov2lcov-action@v1.0.8
+      #   with:
+      #     infile: monoskope.coverprofile
+      # - name: Coveralls GitHub Action
+      #   uses: coverallsapp/github-action@1.1.3
+      #   with:
+      #     github-token: ${{ secrets.github_token }}
+      #     path-to-lcov: coverage.lcov

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -57,7 +57,6 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
           GINKGO=ginkgo make go-test-ci
-          make go-coverage
       - name: Convert coverage to lcov
         uses: jandelgado/gcov2lcov-action@v1.0.8
         with:

--- a/build/package/helm/gateway/files/policies/policies.rego
+++ b/build/package/helm/gateway/files/policies/policies.rego
@@ -7,8 +7,11 @@ default authorized = false
 # list of allowed paths for any user
 allowed_paths := [
 	"/gateway.Gateway/",
+	"/domain.Cluster/GetAll/",
+	"/domain.Cluster/GetByName/",
 	"/gateway.ClusterAuth/GetAuthToken/",
 	"/domain.CommandHandlerExtensions/",
+	"/common.ServiceInformationService/GetServiceInformation",
 	"/domain.Cluster/GetByName",
 ]
 

--- a/go.mk
+++ b/go.mk
@@ -6,10 +6,10 @@ GO             ?= go
 GOGET          ?= $(HACK_DIR)/goget-wrapper
 
 GINKGO         ?= $(TOOLS_DIR)/ginkgo
-GINKO_VERSION  ?= v1.16.4
+GINKO_VERSION  ?= v1.16.5
 
 LINTER 	   	   ?= $(TOOLS_DIR)/golangci-lint
-LINTER_VERSION ?= v1.45.2
+LINTER_VERSION ?= v1.46.1
 
 MOCKGEN         ?= $(TOOLS_DIR)/mockgen
 GOMOCK_VERSION  ?= v1.5.0


### PR DESCRIPTION
Currently cluster login is impossible due to the strict policies and even the version command fails with permission denied.