### PR TITLE
update rabbitmq chart to the latest available 8.x.x chart version

### DIFF
--- a/build/package/helm/monoskope/Chart.yaml
+++ b/build/package/helm/monoskope/Chart.yaml
@@ -52,7 +52,7 @@ dependencies: # A list of the chart requirements
     repository: https://charts.cockroachdb.com/
     condition: cockroachdb.enabled,global.cockroachdb.enabled
   - name: rabbitmq
-    version: 8.24.3
+    version: 8.32.2
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled,global.rabbitmq.enabled
   - name: ambassador


### PR DESCRIPTION
Signed-off-by: Christian Hüning <christian.huening@finleap.com>

* update RabbitMQ Chart to 8.32.2

work towards #161 