### PR TITLE
Ignore deleted tenants on tenant users

### DIFF
--- a/pkg/domain/queryhandler.go
+++ b/pkg/domain/queryhandler.go
@@ -46,7 +46,7 @@ func NewQueryHandlerDomain(ctx context.Context, eventBus eventsourcing.EventBusC
 	d.UserRoleBindingRepository = repositories.NewUserRoleBindingRepository(esr.NewInMemoryRepository[*projections.UserRoleBinding]())
 	d.UserRepository = repositories.NewUserRepository(esr.NewInMemoryRepository[*projections.User](), d.UserRoleBindingRepository)
 	d.TenantRepository = repositories.NewTenantRepository(esr.NewInMemoryRepository[*projections.Tenant]())
-	d.TenantUserRepository = repositories.NewTenantUserRepository(d.UserRepository, d.UserRoleBindingRepository)
+	d.TenantUserRepository = repositories.NewTenantUserRepository(d.UserRepository, d.UserRoleBindingRepository, d.TenantRepository)
 	d.ClusterRepository = repositories.NewClusterRepository(esr.NewInMemoryRepository[*projections.Cluster]())
 	d.TenantClusterBindingRepository = repositories.NewTenantClusterBindingRepository(esr.NewInMemoryRepository[*projections.TenantClusterBinding]())
 	d.ClusterAccessRepo = repositories.NewClusterAccessRepository(d.TenantClusterBindingRepository, d.ClusterRepository, d.UserRoleBindingRepository)

--- a/pkg/domain/repositories/tenant_user_repo_test.go
+++ b/pkg/domain/repositories/tenant_user_repo_test.go
@@ -59,10 +59,11 @@ var _ = Describe("domain/tenant_user_repo_test", func() {
 	It("can read/write projections", func() {
 		inMemoryTenantRepo := es_repos.NewInMemoryRepository[*projections.Tenant]()
 		tenantRepo := NewTenantRepository(inMemoryTenantRepo)
-		tenantRepo.Upsert(context.Background(), tenant)
+		err := tenantRepo.Upsert(context.Background(), tenant)
+		Expect(err).NotTo(HaveOccurred())
 
 		inMemoryRoleRepo := es_repos.NewInMemoryRepository[*projections.UserRoleBinding]()
-		err := inMemoryRoleRepo.Upsert(context.Background(), adminRoleBinding)
+		err = inMemoryRoleRepo.Upsert(context.Background(), adminRoleBinding)
 		Expect(err).NotTo(HaveOccurred())
 		err = inMemoryRoleRepo.Upsert(context.Background(), otherUserRoleBinding)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When a tenant has been deleted, the users of this tenant can still be queried as if the tenant would still exist. This fixes this by skipping deleted tenant on the server side.