### PR TITLE
Make ClusterBootstrapTokenCreated known again

### DIFF
--- a/pkg/domain/constants/events/events.go
+++ b/pkg/domain/constants/events/events.go
@@ -42,6 +42,8 @@ const (
 	ClusterUpdated es.EventType = "ClusterUpdated"
 	// ClusterDeleted event emitted when a Cluster has been deleted
 	ClusterDeleted es.EventType = "ClusterDeleted"
+	// IGNORED: ClusterBootstrapTokenCreated event emitted when a bootstrap token has been created
+	ClusterBootstrapTokenCreated es.EventType = "ClusterBootstrapTokenCreated"
 
 	// CertificateRequested event emitted when a certificate has been requested
 	CertificateRequested es.EventType = "CertificateRequested"

--- a/pkg/domain/projectors/cluster.go
+++ b/pkg/domain/projectors/cluster.go
@@ -90,6 +90,8 @@ func (c *clusterProjector) Project(ctx context.Context, event es.Event, cluster 
 		if err := c.projectDeleted(event, cluster.DomainProjection); err != nil {
 			return nil, err
 		}
+	case events.ClusterBootstrapTokenCreated:
+		// IGNORED, not in use anymore
 	default:
 		return nil, errors.ErrInvalidEventType
 	}


### PR DESCRIPTION
In previous changes the cluster bootstrap token has been removed, but due to the nature of event sourcing the events are still in the history. Therefore it is not a viable solution to remove the handling of those events. Readded a dummy handler again.