### PR TITLE
Readd handler for former events

### DIFF
--- a/pkg/domain/aggregates/cluster.go
+++ b/pkg/domain/aggregates/cluster.go
@@ -161,6 +161,8 @@ func (a *ClusterAggregate) ApplyEvent(event es.Event) error {
 		if len(data.GetCaCertificateBundle()) > 0 && !bytes.Equal(a.caCertBundle, data.GetCaCertificateBundle()) {
 			a.caCertBundle = data.GetCaCertificateBundle()
 		}
+	case events.ClusterBootstrapTokenCreated:
+		// IGNORED, not in use anymore
 	case events.ClusterDeleted:
 		a.SetDeleted(true)
 	default:


### PR DESCRIPTION
The removal of the handler for ClusterBootstrapTokenCreated breaks handling if the EventStore has events of that type for historical reasons. The handler is readded.