### PR TITLE
Fix roles/tenants/clusters values are missing from the audit log users overview

### DIFF
--- a/internal/queryhandler/audit_log_server.go
+++ b/internal/queryhandler/audit_log_server.go
@@ -21,19 +21,19 @@ import (
 	"time"
 
 	"github.com/finleap-connect/monoskope/internal/gateway/auth"
+	doApi "github.com/finleap-connect/monoskope/pkg/api/domain"
 	esApi "github.com/finleap-connect/monoskope/pkg/api/eventsourcing"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/audit"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/aggregates"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/events"
-	"github.com/finleap-connect/monoskope/pkg/domain/repositories"
-	"github.com/google/uuid"
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
-	doApi "github.com/finleap-connect/monoskope/pkg/api/domain"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	"github.com/finleap-connect/monoskope/pkg/domain/errors"
+	"github.com/finleap-connect/monoskope/pkg/domain/repositories"
 	grpcUtil "github.com/finleap-connect/monoskope/pkg/grpc"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // auditLogServer is the implementation of the auditLogService API
@@ -119,7 +119,7 @@ func (s *auditLogServer) GetByUser(request *doApi.GetByUserRequest, stream doApi
 		}
 
 		hre := s.auditFormatter.NewHumanReadableEvent(stream.Context(), e)
-		if !strings.Contains(hre.Details, "“"+user.Email+"“") || hre.IssuerId == user.Id {
+		if !strings.Contains(hre.Details, fConsts.Quote(user.Email)) || hre.IssuerId == user.Id {
 			continue // skip e.g. UserRoleBindings that doesn't affect the given user or were created by him
 		}
 		err = stream.Send(hre)

--- a/internal/testenv.go
+++ b/internal/testenv.go
@@ -15,17 +15,19 @@
 package internal
 
 import (
+	"os"
+	"strings"
+
 	"github.com/finleap-connect/monoskope/internal/commandhandler"
 	"github.com/finleap-connect/monoskope/internal/eventstore"
 	"github.com/finleap-connect/monoskope/internal/gateway"
 	"github.com/finleap-connect/monoskope/internal/queryhandler"
-	"os"
-
 	"github.com/finleap-connect/monoskope/internal/test"
 )
 
 type TestEnv struct {
 	*test.TestEnv
+	superUsers            []string
 	gatewayTestEnv        *gateway.TestEnv
 	eventStoreTestEnv     *eventstore.TestEnv
 	queryHandlerTestEnv   *queryhandler.TestEnv
@@ -38,7 +40,8 @@ func NewTestEnv(testEnv *test.TestEnv) (*TestEnv, error) {
 		TestEnv: testEnv,
 	}
 
-	os.Setenv("SUPER_USERS", "admin@monoskope.io,other-admin@monoskope.io")
+	env.superUsers = []string{"admin@monoskope.io", "other-admin@monoskope.io"}
+	os.Setenv("SUPER_USERS", strings.Join(env.superUsers, ","))
 
 	env.gatewayTestEnv, err = gateway.NewTestEnvWithParent(testEnv)
 	if err != nil {

--- a/pkg/audit/formatters/audit/audit_formatter.go
+++ b/pkg/audit/formatters/audit/audit_formatter.go
@@ -23,6 +23,7 @@ import (
 	esApi "github.com/finleap-connect/monoskope/pkg/api/eventsourcing"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	_ "github.com/finleap-connect/monoskope/pkg/domain/formatters/events"
 	"github.com/finleap-connect/monoskope/pkg/domain/formatters/overviews"
 	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
@@ -56,7 +57,7 @@ func NewAuditFormatter(esClient esApi.EventStoreClient, efRegistry event.EventFo
 // NewHumanReadableEvent creates a HumanReadableEvent of a given event
 func (f *auditFormatter) NewHumanReadableEvent(ctx context.Context, event *esApi.Event) *audit.HumanReadableEvent {
 	humanReadableEvent := &audit.HumanReadableEvent{
-		When:      event.Timestamp.AsTime().Format(time.RFC822),
+		When:      event.Timestamp.AsTime().Format(fConsts.TimeFormat),
 		Issuer:    event.Metadata[auth.HeaderAuthEmail],
 		IssuerId:  event.Metadata[auth.HeaderAuthId],
 		EventType: event.Type,

--- a/pkg/audit/formatters/user_snapshotter.go
+++ b/pkg/audit/formatters/user_snapshotter.go
@@ -1,0 +1,91 @@
+// Copyright 2022 Monoskope Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatters
+
+import (
+	"context"
+	"github.com/finleap-connect/monoskope/pkg/domain/constants/aggregates"
+	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"io"
+	"time"
+
+	esApi "github.com/finleap-connect/monoskope/pkg/api/eventsourcing"
+	"github.com/finleap-connect/monoskope/pkg/domain/projections"
+	es "github.com/finleap-connect/monoskope/pkg/eventsourcing"
+	"github.com/google/uuid"
+)
+
+// UserSnapshotter implements basic snapshot creation for the user aggregate
+type UserSnapshotter struct {
+	*Snapshotter[*projections.User]
+}
+
+func NewUserSnapshotter(esClient esApi.EventStoreClient, projector es.Projector[*projections.User]) *UserSnapshotter {
+	return &UserSnapshotter{Snapshotter: &Snapshotter[*projections.User]{esClient, projector}}
+}
+
+// CreateRoleBindingSnapshots returns a list of userRoleBinding snapshots for the user specified by its id
+// This is a temporary implementation until snapshots are fully implemented,
+// and it is not meant to be used extensively.
+func (s *UserSnapshotter) CreateRoleBindingSnapshots(ctx context.Context, userId uuid.UUID, timestamp time.Time) []*projections.UserRoleBinding {
+	var userRoleBindings []*projections.UserRoleBinding
+	roleBindingEvents, err := s.esClient.Retrieve(ctx, &esApi.EventFilter{
+		MaxTimestamp:  timestamppb.New(timestamp),
+		AggregateType: wrapperspb.String(aggregates.UserRoleBinding.String()),
+	})
+	if err != nil {
+		return userRoleBindings
+	}
+
+	roleBindingProjector := projectors.NewUserRoleBindingProjector()
+	roleBindings := make(map[string]*projections.UserRoleBinding)
+	for {
+		eventPorto, err := roleBindingEvents.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			continue
+		}
+
+		e, err := es.NewEventFromProto(eventPorto)
+		if err != nil {
+			continue
+		}
+
+		userRoleBinding, exist := roleBindings[e.AggregateID().String()]
+		if !exist {
+			userRoleBinding = roleBindingProjector.NewProjection(e.AggregateID())
+			roleBindings[e.AggregateID().String()] = userRoleBinding
+		}
+
+		if userRoleBinding.UserId != "" && userRoleBinding.UserId != userId.String() {
+			continue // after projecting once to ensure the roleBinding is irrelevant
+		}
+
+		userRoleBinding, err = roleBindingProjector.Project(ctx, e, userRoleBinding)
+		if err != nil {
+			continue
+		}
+
+		if !exist && userRoleBinding.UserId == userId.String() {
+			userRoleBindings = append(userRoleBindings, userRoleBinding)
+		}
+	}
+
+	return userRoleBindings
+}

--- a/pkg/domain/constants/formatters/formatters.go
+++ b/pkg/domain/constants/formatters/formatters.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Monoskope Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatters
+
+import (
+	"fmt"
+	"time"
+)
+
+type DetailsFormat string
+
+const (
+	TimeFormat       = time.RFC822
+	LeftQuoteSymbol  = "“"
+	RightQuoteSymbol = "“"
+
+	UserCreatedDetailsFormat            DetailsFormat = "“%s“ created user “%s“"
+	UserUpdatedDetailsFormat            DetailsFormat = "“%s“ updated the User"
+	UserRoleAddedDetailsFormat          DetailsFormat = "“%s“ assigned the role “%s“ for scope “%s“ to user “%s“"
+	UserDeletedDetailsFormat            DetailsFormat = "“%s“ deleted user “%s“"
+	UserRoleBindingDeletedDetailsFormat DetailsFormat = "“%s“ removed the role “%s“ for scope “%s“ from user “%s“"
+
+	TenantCreatedDetailsFormat               DetailsFormat = "“%s“ created tenant “%s“ with prefix “%s“"
+	TenantUpdatedDetailsFormat               DetailsFormat = "“%s“ updated the Tenant"
+	TenantClusterBindingCreatedDetailsFormat DetailsFormat = "“%s“ bounded tenant “%s“ to cluster “%s”"
+	TenantDeletedDetailsFormat               DetailsFormat = "“%s“ deleted tenant “%s“"
+	TenantClusterBindingDeletedDetailsFormat DetailsFormat = "“%s“ deleted the bound between cluster “%s“ and tenant “%s“"
+
+	ClusterCreatedDetailsFormat   DetailsFormat = "“%s“ created cluster “%s“"
+	ClusterCreatedV2DetailsFormat DetailsFormat = ClusterCreatedDetailsFormat
+	ClusterUpdatedDetailsFormat   DetailsFormat = "“%s“ updated the cluster"
+	ClusterDeletedDetailsFormat   DetailsFormat = "“%s“ deleted cluster “%s“"
+
+	RequestIssuedDetailsFormat            DetailsFormat = "“%s“ issued a certificate request"
+	CertificateRequestedDetailsFormat     DetailsFormat = "“%s“ requested a certificate"
+	CertificateIssuedDetailsFormat        DetailsFormat = "“%s“ issued a certificate"
+	CertificateIssuingFailedDetailsFormat DetailsFormat = "certificate request issuing faild for “%s“"
+
+	UserCreatedOverviewDetailsFormat            DetailsFormat = "“%s“ was created by “%s“ at “%s“"
+	UserDeletedOverviewDetailsFormat            DetailsFormat = " and was deleted by “%s“ at “%s“"
+	UserRoleBindingOverviewDetailsFormat        DetailsFormat = "- %s %s\n"
+	TenantUserRoleBindingOverviewDetailsFormat  DetailsFormat = "- %s (%s)\n"
+	ClusterUserRoleBindingOverviewDetailsFormat DetailsFormat = TenantUserRoleBindingOverviewDetailsFormat
+)
+
+// Sprint returns the resulting string after formatting.
+func (f DetailsFormat) Sprint(args ...interface{}) string {
+	return fmt.Sprintf(string(f), args...)
+}
+
+func Quote(str string) string {
+	return LeftQuoteSymbol + str + RightQuoteSymbol
+}

--- a/pkg/domain/formatters/events/certificate.go
+++ b/pkg/domain/formatters/events/certificate.go
@@ -16,13 +16,13 @@ package events
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/finleap-connect/monoskope/internal/gateway/auth"
 	esApi "github.com/finleap-connect/monoskope/pkg/api/eventsourcing"
 	"github.com/finleap-connect/monoskope/pkg/audit/errors"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/events"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	es "github.com/finleap-connect/monoskope/pkg/eventsourcing"
 )
 
@@ -62,17 +62,17 @@ func (f *certificateEventFormatter) GetFormattedDetails(_ context.Context, event
 }
 
 func (f *certificateEventFormatter) getFormattedDetailsCertificateRequestIssued(event *esApi.Event) (string, error) {
-	return fmt.Sprintf("“%s“ issued a certificate request", event.Metadata[auth.HeaderAuthEmail]), nil
+	return fConsts.RequestIssuedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]), nil
 }
 
 func (f *certificateEventFormatter) getFormattedDetailsCertificateRequested(event *esApi.Event) (string, error) {
-	return fmt.Sprintf("“%s“ requested a certificate", event.Metadata[auth.HeaderAuthEmail]), nil
+	return fConsts.CertificateRequestedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]), nil
 }
 
 func (f *certificateEventFormatter) getFormattedDetailsCertificateIssued(event *esApi.Event) (string, error) {
-	return fmt.Sprintf("“%s“ issued a certificate", event.Metadata[auth.HeaderAuthEmail]), nil
+	return fConsts.CertificateIssuedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]), nil
 }
 
 func (f *certificateEventFormatter) getFormattedDetailsCertificateIssuingFailed(event *esApi.Event) (string, error) {
-	return fmt.Sprintf("certificate request issuing faild for “%s“", event.Metadata[auth.HeaderAuthEmail]), nil
+	return fConsts.CertificateIssuingFailedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]), nil
 }

--- a/pkg/domain/formatters/events/cluster.go
+++ b/pkg/domain/formatters/events/cluster.go
@@ -16,7 +16,6 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/events"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
 	es "github.com/finleap-connect/monoskope/pkg/eventsourcing"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -77,11 +77,11 @@ func (f *clusterEventFormatter) GetFormattedDetails(ctx context.Context, event *
 }
 
 func (f *clusterEventFormatter) getFormattedDetailsClusterCreated(event *esApi.Event, eventData *eventdata.ClusterCreated) (string, error) {
-	return fmt.Sprintf("“%s“ created cluster “%s“", event.Metadata[auth.HeaderAuthEmail], eventData.Name), nil
+	return fConsts.ClusterCreatedV2DetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], eventData.Name), nil
 }
 
 func (f *clusterEventFormatter) getFormattedDetailsClusterCreatedV2(event *esApi.Event, eventData *eventdata.ClusterCreatedV2) (string, error) {
-	return fmt.Sprintf("“%s“ created cluster “%s“", event.Metadata[auth.HeaderAuthEmail], eventData.Name), nil
+	return fConsts.ClusterCreatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], eventData.Name), nil
 }
 
 func (f *clusterEventFormatter) getFormattedDetailsClusterUpdated(ctx context.Context, event *esApi.Event, eventData *eventdata.ClusterUpdated) (string, error) {
@@ -96,7 +96,7 @@ func (f *clusterEventFormatter) getFormattedDetailsClusterUpdated(ctx context.Co
 	}
 
 	var details strings.Builder
-	details.WriteString(fmt.Sprintf("“%s“ updated the cluster", event.Metadata[auth.HeaderAuthEmail]))
+	details.WriteString(fConsts.ClusterUpdatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]))
 	f.AppendUpdate("Display name", eventData.DisplayName, cluster.DisplayName, &details)
 	f.AppendUpdate("API server address", eventData.ApiServerAddress, cluster.ApiServerAddress, &details)
 	if len(eventData.CaCertificateBundle) != 0 {
@@ -116,5 +116,5 @@ func (f *clusterEventFormatter) getFormattedDetailsClusterDeleted(ctx context.Co
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ deleted cluster “%s“", event.Metadata[auth.HeaderAuthEmail], cluster.DisplayName), nil
+	return fConsts.ClusterDeletedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], cluster.DisplayName), nil
 }

--- a/pkg/domain/formatters/events/tenant.go
+++ b/pkg/domain/formatters/events/tenant.go
@@ -16,7 +16,6 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/events"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
 	es "github.com/finleap-connect/monoskope/pkg/eventsourcing"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -79,7 +79,7 @@ func (f *tenantEventFormatter) GetFormattedDetails(ctx context.Context, event *e
 }
 
 func (f *tenantEventFormatter) getFormattedDetailsTenantCreated(event *esApi.Event, eventData *eventdata.TenantCreated) (string, error) {
-	return fmt.Sprintf("“%s“ created tenant “%s“ with prefix “%s“", event.Metadata[auth.HeaderAuthEmail], eventData.Name, eventData.Prefix), nil
+	return fConsts.TenantCreatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], eventData.Name, eventData.Prefix), nil
 }
 
 func (f *tenantEventFormatter) getFormattedDetailsTenantUpdated(ctx context.Context, event *esApi.Event, eventData *eventdata.TenantUpdated) (string, error) {
@@ -94,7 +94,7 @@ func (f *tenantEventFormatter) getFormattedDetailsTenantUpdated(ctx context.Cont
 	}
 
 	var details strings.Builder
-	details.WriteString(fmt.Sprintf("“%s“ updated the Tenant", event.Metadata[auth.HeaderAuthEmail]))
+	details.WriteString(fConsts.TenantUpdatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]))
 	f.AppendUpdate("Name", eventData.Name.Value, tenant.Name, &details)
 	return details.String(), nil
 }
@@ -116,7 +116,7 @@ func (f *tenantEventFormatter) getFormattedDetailsTenantClusterBindingCreated(ct
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ bounded tenant “%s“ to cluster “%s”",
+	return fConsts.TenantClusterBindingCreatedDetailsFormat.Sprint(
 		event.Metadata[auth.HeaderAuthEmail], tenant.Name, cluster.DisplayName), nil
 }
 
@@ -130,7 +130,7 @@ func (f *tenantEventFormatter) getFormattedDetailsTenantDeleted(ctx context.Cont
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ deleted tenant “%s“", event.Metadata[auth.HeaderAuthEmail], tenant.Name), nil
+	return fConsts.TenantDeletedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], tenant.Name), nil
 }
 
 func (f *tenantEventFormatter) getFormattedDetailsTenantClusterBindingDeleted(ctx context.Context, event *esApi.Event) (string, error) {
@@ -157,6 +157,6 @@ func (f *tenantEventFormatter) getFormattedDetailsTenantClusterBindingDeleted(ct
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ deleted the bound between cluster “%s“ and tenant “%s“",
+	return fConsts.TenantClusterBindingDeletedDetailsFormat.Sprint(
 		event.Metadata[auth.HeaderAuthEmail], cluster.DisplayName, tenant.Name), nil
 }

--- a/pkg/domain/formatters/events/user.go
+++ b/pkg/domain/formatters/events/user.go
@@ -16,7 +16,6 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters/event"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/events"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
 	es "github.com/finleap-connect/monoskope/pkg/eventsourcing"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -79,7 +79,7 @@ func (f *userEventFormatter) GetFormattedDetails(ctx context.Context, event *esA
 }
 
 func (f *userEventFormatter) getFormattedDetailsUserCreated(event *esApi.Event, eventData *eventdata.UserCreated) (string, error) {
-	return fmt.Sprintf("“%s“ created user “%s“", event.Metadata[auth.HeaderAuthEmail], eventData.Email), nil
+	return fConsts.UserCreatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], eventData.Email), nil
 }
 
 func (f *userEventFormatter) getFormattedDetailsUserUpdated(ctx context.Context, event *esApi.Event, eventData *eventdata.UserUpdated) (string, error) {
@@ -93,7 +93,7 @@ func (f *userEventFormatter) getFormattedDetailsUserUpdated(ctx context.Context,
 	}
 
 	var details strings.Builder
-	details.WriteString(fmt.Sprintf("“%s“ updated the User", event.Metadata[auth.HeaderAuthEmail]))
+	details.WriteString(fConsts.UserUpdatedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail]))
 	f.AppendUpdate("Name", eventData.Name, user.Name, &details)
 	return details.String(), nil
 }
@@ -108,7 +108,7 @@ func (f *userEventFormatter) getFormattedDetailsUserRoleAdded(ctx context.Contex
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ assigned the role “%s“ for scope “%s“ to user “%s“",
+	return fConsts.UserRoleAddedDetailsFormat.Sprint(
 		event.Metadata[auth.HeaderAuthEmail], eventData.Role, eventData.Scope, user.Email), nil
 }
 
@@ -122,7 +122,7 @@ func (f *userEventFormatter) getFormattedDetailsUserDeleted(ctx context.Context,
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ deleted user “%s“", event.Metadata[auth.HeaderAuthEmail], user.Email), nil
+	return fConsts.UserDeletedDetailsFormat.Sprint(event.Metadata[auth.HeaderAuthEmail], user.Email), nil
 }
 
 func (f *userEventFormatter) getFormattedDetailsUserRoleBindingDeleted(ctx context.Context, event *esApi.Event) (string, error) {
@@ -142,6 +142,6 @@ func (f *userEventFormatter) getFormattedDetailsUserRoleBindingDeleted(ctx conte
 		return "", err
 	}
 
-	return fmt.Sprintf("“%s“ removed the role “%s“ for scope “%s“ from user “%s“",
+	return fConsts.UserRoleBindingDeletedDetailsFormat.Sprint(
 		event.Metadata[auth.HeaderAuthEmail], urb.Role, urb.Scope, user.Email), nil
 }

--- a/pkg/domain/formatters/overviews/user.go
+++ b/pkg/domain/formatters/overviews/user.go
@@ -16,7 +16,6 @@ package overviews
 
 import (
 	"context"
-	"fmt"
 	"github.com/finleap-connect/monoskope/pkg/domain/constants/users"
 	"github.com/google/uuid"
 	"strings"
@@ -24,6 +23,7 @@ import (
 
 	esApi "github.com/finleap-connect/monoskope/pkg/api/eventsourcing"
 	"github.com/finleap-connect/monoskope/pkg/audit/formatters"
+	fConsts "github.com/finleap-connect/monoskope/pkg/domain/constants/formatters"
 	"github.com/finleap-connect/monoskope/pkg/domain/projections"
 	"github.com/finleap-connect/monoskope/pkg/domain/projectors"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -54,7 +54,7 @@ func (f *userOverviewFormatter) GetFormattedDetails(ctx context.Context, user *p
 		creator = userProjector.NewProjection(uuid.MustParse(eventFilter.AggregateId.Value))
 		creator.Email = "system@" + users.BASE_DOMAIN
 	}
-	details += fmt.Sprintf("“%s“ was created by “%s“ at “%s“", user.Email, creator.Email, user.GetCreated().AsTime().Format(time.RFC822))
+	details += fConsts.UserCreatedOverviewDetailsFormat.Sprint(user.Email, creator.Email, user.GetCreated().AsTime().Format(fConsts.TimeFormat))
 
 	if len(user.GetDeletedById()) == 0 {
 		return details, nil
@@ -66,7 +66,7 @@ func (f *userOverviewFormatter) GetFormattedDetails(ctx context.Context, user *p
 		deleter = userProjector.NewProjection(uuid.MustParse(eventFilter.AggregateId.Value))
 		deleter.Email = "system@" + users.BASE_DOMAIN
 	}
-	details += fmt.Sprintf(" and was deleted by “%s“ at “%s“", deleter.Email, user.GetDeleted().AsTime().Format(time.RFC822))
+	details += fConsts.UserDeletedOverviewDetailsFormat.Sprint(deleter.Email, user.GetDeleted().AsTime().Format(fConsts.TimeFormat))
 
 	return details, nil
 }
@@ -82,7 +82,7 @@ func (f *userOverviewFormatter) GetRolesDetails(ctx context.Context, user *proje
 			continue
 		}
 
-		roleDetails := fmt.Sprintf("- %s %s\n", role.Scope, role.Role)
+		roleDetails := fConsts.UserRoleBindingOverviewDetailsFormat.Sprint(role.Scope, role.Role)
 		if !strings.Contains(rolesDetails, roleDetails) { // avoid having the same role multiple times
 			rolesDetails += roleDetails
 		}
@@ -96,14 +96,14 @@ func (f *userOverviewFormatter) GetRolesDetails(ctx context.Context, user *proje
 		tenantSnapshotter := formatters.NewSnapshotter(f.esClient, projectors.NewTenantProjector())
 		tenant, err := tenantSnapshotter.CreateSnapshot(ctx, eventFilter)
 		if err == nil {
-			tenantsDetails += fmt.Sprintf("- %s (%s)\n", tenant.Name, role.Role)
+			tenantsDetails += fConsts.TenantUserRoleBindingOverviewDetailsFormat.Sprint(tenant.Name, role.Role)
 			continue // it's either a tenant or cluster
 		}
 
 		clusterSnapshotter := formatters.NewSnapshotter(f.esClient, projectors.NewClusterProjector())
 		cluster, err := clusterSnapshotter.CreateSnapshot(ctx, eventFilter)
 		if err == nil {
-			clustersDetails += fmt.Sprintf("- %s (%s)\n", cluster.DisplayName, role.Role)
+			clustersDetails += fConsts.ClusterUserRoleBindingOverviewDetailsFormat.Sprint(cluster.DisplayName, role.Role)
 		}
 	}
 


### PR DESCRIPTION
when getting the audit log of the users-overview the roles a user has and the tenants/clusters they belong to are missing from the output.

**AC:**

- the mentioned keys should have the “expected” values
- find out how they escaped the tests and fix