### PR TITLE
Enhance server side validation of existing aggregates

### DIFF
--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/finleap-connect/monoskope/internal/gateway/auth"
@@ -125,6 +126,15 @@ var _ = Describe("integration", func() {
 				g.Expect(user.GetEmail()).To(Equal(expectedUserEmail))
 				g.Expect(user.Id).To(Equal(userId.String()))
 			}).Should(Succeed())
+
+			By("ensuring the same user can't be created again")
+			command, err = cmd.AddCommandData(
+				cmd.CreateCommand(uuid.Nil, commandTypes.CreateUser),
+				&cmdData.CreateUserCommandData{Name: expectedUserName,
+					Email: strings.ToUpper(" " + expectedUserEmail + " ")}, // regardless of the case and white spaces
+			)
+			_, err = commandHandlerClient().Execute(ctx, command)
+			Expect(err).To(HaveOccurred())
 
 			By("giving the user system admin role")
 			command, err = cmd.AddCommandData(
@@ -262,6 +272,15 @@ var _ = Describe("integration", func() {
 				g.Expect(tenant.Id).To(Equal(tenantId.String()))
 			}).Should(Succeed())
 
+			By("ensuring the same tenant can't be created again")
+			command, err = cmd.AddCommandData(
+				cmd.CreateCommand(tenantId, commandTypes.CreateTenant),
+				&cmdData.CreateTenantCommandData{Name: strings.ToUpper(" " + expectedTenantName + " "), // regardless of the case and white spaces
+					Prefix: expectedTenantPrefix},
+			)
+			_, err = commandHandlerClient().Execute(ctx, command)
+			Expect(err).To(HaveOccurred())
+
 			By("updating the tenant")
 			command, err = cmd.AddCommandData(
 				cmd.CreateCommand(tenantId, commandTypes.UpdateTenant),
@@ -358,6 +377,16 @@ var _ = Describe("integration", func() {
 				g.Expect(cluster.GetApiServerAddress()).To(Equal(expectedClusterApiServerAddress))
 				g.Expect(cluster.GetCaCertBundle()).To(Equal(expectedClusterCACertBundle))
 			}).Should(Succeed())
+
+			By("ensuring the same cluster can't be created again")
+			command, err = cmd.AddCommandData(
+				cmd.CreateCommand(uuid.Nil, commandTypes.CreateCluster),
+				&cmdData.CreateCluster{DisplayName: expectedClusterDisplayName,
+					Name:             " " + strings.ToUpper(expectedClusterName) + " ", // regardless of the case and white spaces
+					ApiServerAddress: expectedClusterApiServerAddress, CaCertBundle: expectedClusterCACertBundle},
+			)
+			_, err = commandHandlerClient().Execute(ctx, command)
+			Expect(err).To(HaveOccurred())
 
 			By("deleting the cluster")
 			_, err = commandHandlerClient().Execute(ctx, cmd.CreateCommand(clusterId, commandTypes.DeleteCluster))

--- a/pkg/domain/aggregates/cluster.go
+++ b/pkg/domain/aggregates/cluster.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/finleap-connect/monoskope/pkg/api/domain/eventdata"
 	"github.com/finleap-connect/monoskope/pkg/domain/commands"
@@ -114,7 +115,7 @@ func containsCluster(values []es.Aggregate, name string) bool {
 	for _, value := range values {
 		d, ok := value.(*ClusterAggregate)
 		if ok {
-			if !d.Deleted() && d.name == name {
+			if !d.Deleted() && strings.ToLower(strings.TrimSpace(d.name)) == strings.ToLower(strings.TrimSpace(name)) {
 				return true
 			}
 		}

--- a/pkg/domain/aggregates/domain_aggregate.go
+++ b/pkg/domain/aggregates/domain_aggregate.go
@@ -26,7 +26,7 @@ type DomainAggregateBase struct {
 }
 
 // Validate validates if the aggregate exists and is not deleted
-func (a *DomainAggregateBase) Validate(ctx context.Context, cmd es.Command) error {
+func (a *DomainAggregateBase) Validate(_ context.Context, _ es.Command) error {
 	if !a.Exists() {
 		return domainErrors.ErrNotFound
 	}

--- a/pkg/domain/aggregates/tenant.go
+++ b/pkg/domain/aggregates/tenant.go
@@ -17,6 +17,7 @@ package aggregates
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/finleap-connect/monoskope/pkg/api/domain/eventdata"
 	"github.com/finleap-connect/monoskope/pkg/domain/commands"
@@ -79,7 +80,7 @@ func containsTenant(values []es.Aggregate, name string) bool {
 	for _, value := range values {
 		d, ok := value.(*TenantAggregate)
 		if ok {
-			if !d.Deleted() && d.name == name {
+			if !d.Deleted() && strings.ToLower(strings.TrimSpace(d.name)) == strings.ToLower(strings.TrimSpace(name)) {
 				return true
 			}
 		}

--- a/pkg/domain/aggregates/user.go
+++ b/pkg/domain/aggregates/user.go
@@ -17,6 +17,7 @@ package aggregates
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/finleap-connect/monoskope/pkg/api/domain/common"
 	"github.com/finleap-connect/monoskope/pkg/api/domain/eventdata"
@@ -160,7 +161,7 @@ func containsUser(values []es.Aggregate, emailAddress string) bool {
 	for _, value := range values {
 		d, ok := value.(*UserAggregate)
 		if ok {
-			if !d.Deleted() && d.Email == emailAddress {
+			if !d.Deleted() && strings.ToLower(strings.TrimSpace(d.Email)) == strings.ToLower(strings.TrimSpace(emailAddress)) {
 				return true
 			}
 		}


### PR DESCRIPTION
Currently two tenants with the same name but different case could be created. This must not be possible! For all other aggregates the name must be case insensitive unique!