### PR TITLE
WIP: Use most recent Ambassador / Emissary-Ingress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ project.dict
 
 /gateway
 
-build/package/helm/monoskope/Chart.lock
 build/package/helm/monoskope/charts/**
 .dccache

--- a/build/package/helm/monoskope/Chart.lock
+++ b/build/package/helm/monoskope/Chart.lock
@@ -1,0 +1,27 @@
+dependencies:
+- name: gateway
+  repository: file://../gateway
+  version: 0.0.1-local
+- name: eventstore
+  repository: file://../eventstore
+  version: 0.0.1-local
+- name: commandhandler
+  repository: file://../commandhandler
+  version: 0.0.1-local
+- name: queryhandler
+  repository: file://../queryhandler
+  version: 0.0.1-local
+- name: scimserver
+  repository: file://../scimserver
+  version: 0.0.1-local
+- name: cockroachdb
+  repository: https://charts.cockroachdb.com/
+  version: 7.0.1
+- name: rabbitmq
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.32.2
+- name: emissary-ingress
+  repository: https://getambassador.io
+  version: 8.0.0
+digest: sha256:76299ec2f3da8693fe07db6183dc3183ef8a56e30007a5388d04e25d6bca8f0c
+generated: "2022-07-27T09:56:50.706907+02:00"

--- a/build/package/helm/monoskope/Chart.yaml
+++ b/build/package/helm/monoskope/Chart.yaml
@@ -51,8 +51,9 @@ dependencies: # A list of the chart requirements
     version: 8.32.2
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled,global.rabbitmq.enabled
-  - name: ambassador
-    version: 6.9.4
+  - helm: emissary-ingress
+    alias: ambassador
+    version: 8.0.0
     repository: https://getambassador.io
     condition: ambassador.deploy,global.ambassador.deploy
 

--- a/build/package/helm/monoskope/Chart.yaml
+++ b/build/package/helm/monoskope/Chart.yaml
@@ -51,7 +51,7 @@ dependencies: # A list of the chart requirements
     version: 8.32.2
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled,global.rabbitmq.enabled
-  - helm: emissary-ingress
+  - name: emissary-ingress
     alias: ambassador
     version: 8.0.0
     repository: https://getambassador.io

--- a/build/package/helm/monoskope/templates/_helpers.tpl
+++ b/build/package/helm/monoskope/templates/_helpers.tpl
@@ -69,20 +69,12 @@ Create the name of the service account to use
 {{- printf "%s-tls-cert" (include "monoskope.fullname" .) }}
 {{- end }}
 
-{{- define "monoskope.mtlsSecretName" -}}
-{{- printf "%s-mtls-cert" (include "monoskope.fullname" .) }}
-{{- end }}
-
 {{- define "monoskope.identityCAName" -}}
 {{- printf "%s-identity" (include "monoskope.fullname" .) }}
 {{- end }}
 
 {{- define "monoskope.domain" -}}
 {{- required "a value for .Values.hosting.domain has to be provided" .Values.hosting.domain }}
-{{- end }}
-
-{{- define "monoskope.mtlsDomain" -}}
-{{- printf "mapi.%s" .Values.hosting.domain }}
 {{- end }}
 
 {{- define "monoskope.tlsDomain" -}}

--- a/build/package/helm/monoskope/templates/ambassador/ambassador-cert.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/ambassador-cert.yaml
@@ -1,8 +1,6 @@
 {{- if .Values.ambassador.enabled }}
 {{- $tlsSecretName := (include "monoskope.tlsSecretName" .) }}
 {{- $tlsDomain := (include "monoskope.tlsDomain" .) }}
-{{- $mtlsSecretName := (include "monoskope.mtlsSecretName" .) }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -20,30 +18,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
   - {{ $tlsDomain }}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: {{ $mtlsSecretName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "monoskope.labels" . | nindent 4 }}
-    {{- with (.Values.labels | default .Values.global.labels) }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  secretName: {{ $mtlsSecretName }}
-  duration: {{ .Values.pki.certificates.duration }}
-  renewBefore: {{ .Values.pki.certificates.renewBefore }}
-  issuerRef:
-    name: {{ .Values.pki.issuer.name }}
-    kind: Issuer
-  subject:
-    organizations:
-      - Monoskope
-  dnsNames:
-  - {{ $mtlsDomain }}
-  usages:
-  - client auth
-  - server auth
 {{- end }}

--- a/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
@@ -14,8 +14,6 @@ metadata:
     {{- end }}
 spec:
   hostname: {{ $tlsDomain }}
-  acmeProvider:
-    authority: none
   tlsSecret:
     name: {{ $tlsSecretName }}
   tlsContext:
@@ -26,10 +24,9 @@ kind: TLSContext
 metadata:
   name: {{ include "monoskope.fullname" . }}-tls
 spec:
-  hosts:
-  - "*"
   secret: {{ $tlsSecretName }}
-  alpn_protocols: h2
+  hosts: ["*"]
+  alpn_protocols: h2,http/1.1
   min_tls_version: v1.2
 {{- end }}
 {{- end }}

--- a/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
@@ -5,7 +5,7 @@
 apiVersion: getambassador.io/v2
 kind: Host
 metadata:
-  name: {{ include "monoskope.fullname" . }}-tls
+  name: {{ include "monoskope.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "monoskope.labels" . | nindent 4 }}
@@ -16,11 +16,15 @@ spec:
   hostname: {{ $tlsDomain }}
   acmeProvider:
     authority: none
+  tlsSecret:
+    name: {{ $tlsSecretName }}
+  tlsContext:
+    name: {{ include "monoskope.fullname" . }}-tls
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: TLSContext
 metadata:
-  name: tls
+  name: {{ include "monoskope.fullname" . }}-tls
 spec:
   hosts:
   - "*"

--- a/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
@@ -25,7 +25,8 @@ metadata:
   name: {{ include "monoskope.fullname" . }}-tls
 spec:
   secret: {{ $tlsSecretName }}
-  hosts: ["*"]
+  hosts:
+    - {{ $tlsDomain }}
   alpn_protocols: h2,http/1.1
   min_tls_version: v1.2
 {{- end }}

--- a/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/ambassador-host.yaml
@@ -1,8 +1,6 @@
 {{- if .Values.ambassador.enabled }}
 {{- $tlsSecretName := (include "monoskope.tlsSecretName" .) }}
-{{- $mtlsSecretName := (include "monoskope.mtlsSecretName" .) }}
 {{- $tlsDomain := (include "monoskope.tlsDomain" .) }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 {{- if ne $tlsDomain "" }}
 apiVersion: getambassador.io/v2
 kind: Host
@@ -18,30 +16,16 @@ spec:
   hostname: {{ $tlsDomain }}
   acmeProvider:
     authority: none
-  tlsSecret:
-    name: {{ $tlsSecretName }}
-  tls:
-    min_tls_version: v1.2
 ---
-{{- end }}
-{{- if ne $mtlsDomain "" }}
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: TLSContext
 metadata:
-  name: {{ include "monoskope.fullname" . }}-mtls
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "monoskope.labels" . | nindent 4 }}
-    {{- with (.Values.labels | default .Values.global.labels) }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  name: tls
 spec:
   hosts:
-  - {{ $mtlsDomain }}
-  - {{ $mtlsDomain }}:443
-  secret: {{ $mtlsSecretName }}
-  ca_secret: {{ .Values.pki.issuer.ca.existingTrustAnchorSecretName | default (printf "%s-trust-anchor" (include "monoskope.fullname" .)) }}
-  cert_required: true
+  - "*"
+  secret: {{ $tlsSecretName }}
+  alpn_protocols: h2
   min_tls_version: v1.2
 {{- end }}
 {{- end }}

--- a/build/package/helm/monoskope/templates/ambassador/mappings/commandhandler.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/commandhandler.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ambassador.enabled }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 {{- if .Values.commandhandler.enabled }}
 apiVersion: getambassador.io/v2
 kind: Mapping

--- a/build/package/helm/monoskope/templates/ambassador/mappings/commandhandler.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/commandhandler.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /eventsourcing.CommandHandler/
   rewrite: /eventsourcing.CommandHandler/
   service: {{.Release.Name}}-commandhandler:{{.Values.commandhandler.ports.api}}
@@ -24,7 +24,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.CommandHandlerExtensions/
   rewrite: /domain.CommandHandlerExtensions/
   service: {{.Release.Name}}-commandhandler:{{.Values.commandhandler.ports.api}}

--- a/build/package/helm/monoskope/templates/ambassador/mappings/gateway.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/gateway.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /gateway.Gateway/
   rewrite: /gateway.Gateway/
   service: {{.Release.Name}}-gateway:{{.Values.gateway.service.grpcApiPort}}
@@ -30,7 +30,7 @@ metadata:
     {{- end }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /gateway.ClusterAuth/
   rewrite: /gateway.ClusterAuth/
   service: {{.Release.Name}}-gateway:{{.Values.gateway.service.grpcApiPort}}
@@ -44,7 +44,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /common.ServiceInformationService/
   rewrite: /common.ServiceInformationService/
   service: {{.Release.Name}}-gateway:{{.Values.gateway.service.grpcApiPort}}
@@ -87,7 +87,7 @@ metadata:
     {{- end }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /gateway.APIToken/
   rewrite: /gateway.APIToken/
   service: {{.Release.Name}}-gateway:{{.Values.gateway.service.grpcApiPort}}

--- a/build/package/helm/monoskope/templates/ambassador/mappings/gateway.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/gateway.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ambassador.enabled }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 {{- if .Values.gateway.enabled }}
 apiVersion: getambassador.io/v2
 kind: Mapping

--- a/build/package/helm/monoskope/templates/ambassador/mappings/queryhandler.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/queryhandler.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.User/
   rewrite: /domain.User/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}
@@ -24,7 +24,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.Tenant/
   rewrite: /domain.Tenant/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}
@@ -38,7 +38,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.Cluster/
   rewrite: /domain.Cluster/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}
@@ -52,7 +52,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.ClusterAccess/
   rewrite: /domain.ClusterAccess/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}
@@ -66,7 +66,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.Certificate/
   rewrite: /domain.Certificate/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}
@@ -80,7 +80,7 @@ metadata:
     {{- include "monoskope.labels" . | nindent 4 }}
 spec:
   grpc: true
-  timeout_ms: 20000
+  hostname: "*"
   prefix: /domain.AuditLog/
   rewrite: /domain.AuditLog/
   service: {{.Release.Name}}-queryhandler:{{.Values.queryhandler.ports.api}}

--- a/build/package/helm/monoskope/templates/ambassador/mappings/queryhandler.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/queryhandler.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ambassador.enabled }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 {{- if .Values.queryhandler.enabled }}
 apiVersion: getambassador.io/v2
 kind: Mapping

--- a/build/package/helm/monoskope/templates/ambassador/mappings/scimserver.yaml
+++ b/build/package/helm/monoskope/templates/ambassador/mappings/scimserver.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ambassador.enabled }}
-{{- $mtlsDomain := (include "monoskope.mtlsDomain" .) }}
 {{- if .Values.scimserver.enabled }}
 apiVersion: getambassador.io/v2
 kind: Mapping

--- a/build/package/helm/monoskope/values.yaml
+++ b/build/package/helm/monoskope/values.yaml
@@ -72,12 +72,12 @@ eventstore:
     tlsSecret: *msgBusClientAuthCertSecretName
   storeDatabase:
     configSecret: "m8-db-client-config"
-    tlsSecret:  "m8-db-client-auth-cert"
+    tlsSecret: "m8-db-client-auth-cert"
 
 commandhandler:
   enabled: true
   replicaCount: 1
-  
+
 queryhandler:
   enabled: true
   replicaCount: 1
@@ -151,7 +151,7 @@ rabbitmq:
   loadDefinition:
     enabled: true
     existingSecret: m8-rabbitmq-load-definition
-  extraPlugins: 'rabbitmq_auth_mechanism_ssl'
+  extraPlugins: "rabbitmq_auth_mechanism_ssl"
   extraConfiguration: |-
     auth_mechanisms.1 = EXTERNAL
     ssl_cert_login_from = common_name
@@ -164,7 +164,7 @@ rabbitmq:
     tlsPort: 5671
   auth:
     username: eventstore # admin user with read/write access
-    password: "w1!!b3r3pl4c3d"  # in case you use VaultOperator this will be overwritten by the load definition which takes the password from a generated secret
+    password: "w1!!b3r3pl4c3d" # in case you use VaultOperator this will be overwritten by the load definition which takes the password from a generated secret
     # -- Name of the secret containing the erlang secret
     # If vaultOperator.enabled:true the secret will eb auto generated
     existingErlangSecret: m8-rabbitmq-erlang-cookie
@@ -184,7 +184,7 @@ ambassador:
   replicaCount: 1
   image:
     repository: docker.io/emissaryingress/emissary
-    tag: 3.0.0
+    tag: 2.3.1
   enableAES: false
   agent:
     enabled: false

--- a/build/package/helm/monoskope/values.yaml
+++ b/build/package/helm/monoskope/values.yaml
@@ -184,7 +184,7 @@ ambassador:
   replicaCount: 1
   image:
     repository: docker.io/emissaryingress/emissary
-    tag: 2.3.1
+    tag: 3.0.0
   agent:
     enabled: false
   rbac:
@@ -198,6 +198,8 @@ ambassador:
       enabled: false
   adminService:
     create: false
+  module:
+    strip_matching_host_port: true # necessary for gRPC, see https://www.getambassador.io/docs/emissary/latest/howtos/grpc/#mappings-with-hosts
 
 scimserver:
   enabled: false

--- a/build/package/helm/monoskope/values.yaml
+++ b/build/package/helm/monoskope/values.yaml
@@ -185,11 +185,7 @@ ambassador:
   image:
     repository: docker.io/emissaryingress/emissary
     tag: 2.3.1
-  enableAES: false
   agent:
-    enabled: false
-  crds:
-    create: false
     enabled: false
   rbac:
     create: false
@@ -197,13 +193,6 @@ ambassador:
     create: true
   scope:
     singleNamespace: true
-  resources:
-    limits:
-      cpu: 4
-      memory: 1000Mi
-    requests:
-      cpu: 100m
-      memory: 512Mi
   metrics:
     serviceMonitor:
       enabled: false

--- a/build/package/helm/monoskope/values.yaml
+++ b/build/package/helm/monoskope/values.yaml
@@ -183,8 +183,8 @@ ambassador:
   deploy: true
   replicaCount: 1
   image:
-    repository: datawire/ambassador
-    tag: 1.14.3
+    repository: docker.io/emissaryingress/emissary
+    tag: 3.0.0
   enableAES: false
   agent:
     enabled: false


### PR DESCRIPTION
This change is mainly required for the newer Emissary-Ingress Helm chart, which deploys RBAC resources in v1.