### PR TITLE
Change tls cert rotation policy to never and rotation docs

### DIFF
--- a/build/package/helm/monoskope/templates/gateway/cert-auth.yaml
+++ b/build/package/helm/monoskope/templates/gateway/cert-auth.yaml
@@ -25,7 +25,7 @@ spec:
     - key encipherment
     - client auth
   privateKey:
-    rotationPolicy: Always
+    rotationPolicy: Never
     algorithm: RSA
     encoding: PKCS1
     size: 2048

--- a/docs/operation/04-k8s-auth.md
+++ b/docs/operation/04-k8s-auth.md
@@ -109,7 +109,7 @@ You're good to go!
 
 ## Certificate rotation
 
-the certificate used by Monoskope to sign and verify k8s tokens has a long expire date by design. 
+The certificate used by Monoskope to sign and verify k8s tokens has a long expire date by design. 
 
 Rotating it can be done easily using the [cert-manager CLI](https://cert-manager.io/docs/reference/cmctl/#renew)
 
@@ -117,4 +117,4 @@ Rotating it can be done easily using the [cert-manager CLI](https://cert-manager
 cmctl renew m8-monoskope-tls-cert
 ```
 
-for more information see [here](https://cert-manager.io/docs/usage/certificate#actions-triggering-private-key-rotation)
+For more information see [here](https://cert-manager.io/docs/usage/certificate#actions-triggering-private-key-rotation)

--- a/docs/operation/04-k8s-auth.md
+++ b/docs/operation/04-k8s-auth.md
@@ -106,3 +106,15 @@ Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.7", GitCom
 ```
 
 You're good to go!
+
+## Certificate rotation
+
+the certificate used by Monoskope to sign and verify k8s tokens has a long expire date by design. 
+
+Rotating it can be done easily using the [cert-manager CLI](https://cert-manager.io/docs/reference/cmctl/#renew)
+
+```shell
+cmctl renew m8-monoskope-tls-cert
+```
+
+for more information see [here](https://cert-manager.io/docs/usage/certificate#actions-triggering-private-key-rotation)


### PR DESCRIPTION
An unexpected cert/private-key rotation by cert-manager might cause K8s auth to fail by leading to a state with new/old tokens and KubeAPIServers using the old/new pub key.