### PR TITLE
Fix QueryHandler doesn't start when K8sAuthz is not configured

### DIFF
--- a/build/package/helm/queryhandler/templates/deployment.yaml
+++ b/build/package/helm/queryhandler/templates/deployment.yaml
@@ -70,8 +70,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.messageBus.configSecret | default (printf "%s-%s" (include "queryhandler.fullname" .) "bus") }}
+            {{- if .Values.k8sAuthZ.enabled }}
             - secretRef:
                 name: {{ .Values.k8sAuthZ.existingSecret | default (printf "%s-%s" (include "queryhandler.fullname" .) "k8sauthz") }}
+            {{- end }}
           args:
             - /app
             - server


### PR DESCRIPTION
The newly introduced k8s authz feature breaks the start of the queryhandler if not configured because it tries to mount a secret which isn’t there.