### PR TITLE
Make worker queues durable

### DIFF
--- a/pkg/eventsourcing/messaging/bus_rabbitmq.go
+++ b/pkg/eventsourcing/messaging/bus_rabbitmq.go
@@ -191,6 +191,8 @@ func (b *rabbitEventBus) addHandler(ctx context.Context, handler evs.EventHandle
 	}
 	if workQueueName == "" {
 		options = append(options, rabbitmq.WithConsumeOptionsQueueExclusive)
+	} else {
+		options = append(options, rabbitmq.WithConsumeOptionsQueueDurable)
 	}
 
 	err := b.consumer.StartConsuming(


### PR DESCRIPTION
In some use cases, it is beneficial if the queue that a worker consumes from is made durable. In that way, the queue and the messages would survive a restart of the RabbitMQ server.