### PR TITLE
Use quorum queues for higher reliability

### DIFF
--- a/pkg/eventsourcing/messaging/bus_rabbitmq.go
+++ b/pkg/eventsourcing/messaging/bus_rabbitmq.go
@@ -192,7 +192,7 @@ func (b *rabbitEventBus) addHandler(ctx context.Context, handler evs.EventHandle
 	if workQueueName == "" {
 		options = append(options, rabbitmq.WithConsumeOptionsQueueExclusive)
 	} else {
-		options = append(options, rabbitmq.WithConsumeOptionsQueueDurable)
+		options = append(options, rabbitmq.WithConsumeOptionsQueueDurable, rabbitmq.WithConsumeOptionsQuorum)
 	}
 
 	err := b.consumer.StartConsuming(


### PR DESCRIPTION
As opposed to the use case of automatically generated, exclusive queues, a named queue should be as reliable as possible. For that reason, I added the durable queue option in #312. Since RabbitMQ 3.8 reliable HA queues are of type quorum which replace the legacy mirrored queues. This merge-request changes the options when creating named queues accordingly.