### PR TITLE
Feat/support k8s 1.25

### DIFF
--- a/build/package/helm/commandhandler/templates/hpa.yaml
+++ b/build/package/helm/commandhandler/templates/hpa.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "commandhandler.fullname" . }}

--- a/build/package/helm/commandhandler/templates/hpa.yaml
+++ b/build/package/helm/commandhandler/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "commandhandler.fullname" . }}

--- a/build/package/helm/eventstore/templates/cronjob-backup.yaml
+++ b/build/package/helm/eventstore/templates/cronjob-backup.yaml
@@ -1,6 +1,6 @@
 {{- $merged := merge (deepCopy .Values) (deepCopy (default (dict) .Values.global)) -}}
 {{- if .Values.backup.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "eventstore.fullname" . }}-backup

--- a/build/package/helm/eventstore/templates/cronjob-backup.yaml
+++ b/build/package/helm/eventstore/templates/cronjob-backup.yaml
@@ -1,6 +1,10 @@
 {{- $merged := merge (deepCopy .Values) (deepCopy (default (dict) .Values.global)) -}}
-{{- if .Values.backup.enabled }}
+{{- if .Values.backup.enabled -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
 apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "eventstore.fullname" . }}-backup

--- a/build/package/helm/eventstore/templates/hpa.yaml
+++ b/build/package/helm/eventstore/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "eventstore.fullname" . }}

--- a/build/package/helm/eventstore/templates/hpa.yaml
+++ b/build/package/helm/eventstore/templates/hpa.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "eventstore.fullname" . }}

--- a/build/package/helm/gateway/templates/hpa.yaml
+++ b/build/package/helm/gateway/templates/hpa.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gateway.fullname" . }}

--- a/build/package/helm/gateway/templates/hpa.yaml
+++ b/build/package/helm/gateway/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gateway.fullname" . }}

--- a/build/package/helm/monoskope/Chart.yaml
+++ b/build/package/helm/monoskope/Chart.yaml
@@ -44,7 +44,7 @@ dependencies: # A list of the chart requirements
     repository: "file://../scimserver"
     condition: scimserver.enabled,global.scimserver.enabled
   - name: cockroachdb
-    version: 7.0.1
+    version: 9.1.0
     repository: https://charts.cockroachdb.com/
     condition: cockroachdb.enabled,global.cockroachdb.enabled
   - name: rabbitmq

--- a/build/package/helm/queryhandler/templates/hpa.yaml
+++ b/build/package/helm/queryhandler/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "queryhandler.fullname" . }}

--- a/build/package/helm/queryhandler/templates/hpa.yaml
+++ b/build/package/helm/queryhandler/templates/hpa.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "queryhandler.fullname" . }}

--- a/build/package/helm/scimserver/templates/hpa.yaml
+++ b/build/package/helm/scimserver/templates/hpa.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "scimserver.fullname" . }}

--- a/build/package/helm/scimserver/templates/hpa.yaml
+++ b/build/package/helm/scimserver/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "scimserver.fullname" . }}


### PR DESCRIPTION
Added support for Kubernetes +v1.25

**Changes**

- Added Helm Capabilities check of API versions available for:
  - HorizontalPodAutoscaler
  - CronJob

**Warning**: 
- CockroachDB helm chart version is also updated to v9.1.0, see chart changes [here](https://artifacthub.io/packages/helm/cockroachdb/cockroachdb/9.1.0?modal=template&template=cronjob-ca-certSelfSigner.yaml&compare-to=7.0.1). Default values comparison [here](https://artifacthub.io/packages/helm/cockroachdb/cockroachdb/9.1.0?modal=values&compare-to=7.0.1)
- CockroachDB version is still pinned to the same version as before